### PR TITLE
edit feature for comments

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -103,6 +103,16 @@
   font-size: calc(10px + 0.5vmin);
   font-weight: 300;
 }
+.post-comments .post-comment .side-by-side-edit {
+  display: flex;
+}
+
+.post-comments .post-comment .comment-info .comment-status {
+  font-style: italic;
+  margin-left: 0.5vmin;
+  font-size: calc(9px + 0.5vmin);
+  font-weight: 300;
+}
 
 #comment-form {
   width: 100%;


### PR DESCRIPTION
added edit feature for the comments.
insert the edit button to activate the edit status.
once the status is true, the handle will call the postcomments based on the commentkey to display the original content into the conversation box. send comment will change to edit comment and handled by editComment instead of sendComment.

After the user finished editing, the handleEditComment will update the database accordingly with a status that this comment has been edited and given a new timestamp.
<img width="714" alt="Screenshot 2023-03-13 at 1 51 34 PM" src="https://user-images.githubusercontent.com/108659426/224621249-4c2714e4-dcba-41ea-bd32-25bd6f19e77b.png">


left with designing the interface.