### PR TITLE
Expandable and contractable comment section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -157,14 +157,12 @@
 
 .modal-content-happy .post-comments .post-comment {
   background-color: #d1f7b130;
-  border-right: 2px #d1f7b1 solid;
-  border-bottom: 2px #d1f7b1 solid;
+  border: 1px #d1f7b150 solid;
 }
 
 .modal-content-unhappy .post-comments .post-comment {
   background-color: #fbceb530;
-  border-right: 2px #fbceb5 solid;
-  border-bottom: 2px #fbceb5 solid;
+  border: 1px #fbceb550 solid;
 }
 
 .post-comments .post-comment .comment-info {

--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,10 @@
   display: flex;
 }
 
+.modal-body {
+  padding: 0.5rem 1rem;
+}
+
 .modal-body img {
   max-width: 100%;
 }
@@ -139,7 +143,7 @@
 }
 
 .post-comments {
-  margin: 1vh;
+  margin: 1vh 0;
   font-weight: 600;
   margin-bottom: 1vmin;
 }
@@ -149,35 +153,53 @@
   justify-content: space-between;
   font-weight: 400;
   margin: 0.5vmin 0;
-  border: solid 1px #faedcd;
+}
+
+.modal-content-happy .post-comments .post-comment {
+  background-color: #d1f7b130;
+  border-right: 2px #d1f7b1 solid;
+  border-bottom: 2px #d1f7b1 solid;
+}
+
+.modal-content-unhappy .post-comments .post-comment {
+  background-color: #fbceb530;
+  border-right: 2px #fbceb5 solid;
+  border-bottom: 2px #fbceb5 solid;
 }
 
 .post-comments .post-comment .comment-info {
   font-size: calc(8px + 0.5vmin);
   font-weight: 300;
 }
-.post-comments .post-comment .post-comment-info-status {
+.post-comments .post-comment .post-comment-data {
   display: block;
   padding-left: 0.5vmin;
   margin: 0.3vmin;
 }
-.post-comments .post-comment .post-comment-info-status .user-comment {
+.post-comments .post-comment .post-comment-data .user-comment {
   margin-bottom: 0.7vh;
+  font-size: calc(8px + 0.8vmin);
 }
 
-.post-comments .post-comment .post-comment-info-status .info-status {
+.post-comments .post-comment .post-comment-data .info-status {
   display: flex;
 }
 
-.post-comments .post-comment .post-comment-info-status .comment-status {
+.post-comments .post-comment .post-comment-data .comment-status {
   font-style: italic;
   margin-left: 0.5vmin;
   font-size: calc(8px + 0.5vmin);
   font-weight: 300;
 }
-.post-comments .post-comment .edit-btn {
+
+.comment-section-btns {
   color: #8779ee;
 }
+
+.comment-section-btns button {
+  font-size: calc(8px + 0.5vmin);
+}
+
 #comment-form {
   width: 100%;
 }

--- a/src/Components/Post.js
+++ b/src/Components/Post.js
@@ -217,15 +217,16 @@ export default function Post(props) {
 
         <div className="post-comments">{renderComments(commentSectionLen)}</div>
         <div className="comment-section-btns">
-          {Object.keys(postComments).length > commentSectionLen && (
-            <Button
-              variant="contained"
-              size="sm"
-              onClick={() => setCommentSectionLen((prevLen) => prevLen + 5)}
-            >
-              More comments ↓
-            </Button>
-          )}
+          {postComments &&
+            Object.keys(postComments).length > commentSectionLen && (
+              <Button
+                variant="contained"
+                size="sm"
+                onClick={() => setCommentSectionLen((prevLen) => prevLen + 5)}
+              >
+                More comments ↓
+              </Button>
+            )}
           {commentSectionLen > 5 && (
             <Button
               variant="contained"

--- a/src/Components/Post.js
+++ b/src/Components/Post.js
@@ -146,41 +146,45 @@ export default function Post(props) {
 
   const renderComments = (len = 5) => {
     let comments = [];
-    for (const commentKey in postComments) {
-      comments = [
-        ...comments,
-        <div className="post-comment" key={commentKey}>
-          <div className="post-comment-data">
-            <div className="user-comment">
-              {postComments[commentKey].userComment} {""}
-            </div>{" "}
-            <div className="info-status">
-              <div className="comment-info">
-                {postComments[commentKey].user} {""}{" "}
-                {postComments[commentKey].userCommentDate}
+    if (postComments) {
+      Object.keys(postComments)
+        .reverse()
+        .forEach((commentKey) => {
+          comments = [
+            ...comments,
+            <div className="post-comment" key={commentKey}>
+              <div className="post-comment-data">
+                <div className="user-comment">
+                  {postComments[commentKey].userComment} {""}
+                </div>{" "}
+                <div className="info-status">
+                  <div className="comment-info">
+                    {postComments[commentKey].user} {""}{" "}
+                    {postComments[commentKey].userCommentDate}
+                  </div>
+                  <div className="comment-status">
+                    {postComments[commentKey].status
+                      ? postComments[commentKey].status
+                      : null}
+                  </div>
+                </div>
               </div>
-              <div className="comment-status">
-                {postComments[commentKey].status
-                  ? postComments[commentKey].status
-                  : null}
+              <div className="edit-btn comment-section-btns">
+                {user.email === postComments[commentKey].user ? (
+                  <Button
+                    variant="contained"
+                    size="sm"
+                    id={commentKey}
+                    name="edit"
+                    onClick={handleEdit}
+                  >
+                    EDIT
+                  </Button>
+                ) : null}
               </div>
-            </div>
-          </div>
-          <div className="edit-btn comment-section-btns">
-            {user.email === postComments[commentKey].user ? (
-              <Button
-                variant="contained"
-                size="sm"
-                id={commentKey}
-                name="edit"
-                onClick={handleEdit}
-              >
-                EDIT
-              </Button>
-            ) : null}
-          </div>
-        </div>,
-      ];
+            </div>,
+          ];
+        });
     }
     return comments.slice(0, len);
   };

--- a/src/Components/Post.js
+++ b/src/Components/Post.js
@@ -25,6 +25,7 @@ export default function Post(props) {
   const [postComments, setPostComments] = useState({});
   const [editComment, setEditComment] = useState(false);
   const [editCommentKey, setEditCommentKey] = useState("");
+  const [commentSectionLen, setCommentSectionLen] = useState(5);
 
   useEffect(() => {
     const postRef = ref(database, `${POSTS_DATABASE_KEY}/${postId}`);
@@ -143,13 +144,13 @@ export default function Post(props) {
     }
   };
 
-  const renderComments = () => {
+  const renderComments = (len = 5) => {
     let comments = [];
     for (const commentKey in postComments) {
       comments = [
         ...comments,
         <div className="post-comment" key={commentKey}>
-          <div className="post-comment-info-status">
+          <div className="post-comment-data">
             <div className="user-comment">
               {postComments[commentKey].userComment} {""}
             </div>{" "}
@@ -165,7 +166,7 @@ export default function Post(props) {
               </div>
             </div>
           </div>
-          <div className="edit-btn">
+          <div className="edit-btn comment-section-btns">
             {user.email === postComments[commentKey].user ? (
               <Button
                 variant="contained"
@@ -181,7 +182,7 @@ export default function Post(props) {
         </div>,
       ];
     }
-    return comments;
+    return comments.slice(0, len);
   };
 
   return (
@@ -214,7 +215,27 @@ export default function Post(props) {
           <div className="reaction-btns">{renderReactionButtons()}</div>
         </div>
 
-        <div className="post-comments">{renderComments()}</div>
+        <div className="post-comments">{renderComments(commentSectionLen)}</div>
+        <div className="comment-section-btns">
+          {Object.keys(postComments).length > commentSectionLen && (
+            <Button
+              variant="contained"
+              size="sm"
+              onClick={() => setCommentSectionLen((prevLen) => prevLen + 5)}
+            >
+              More comments ↓
+            </Button>
+          )}
+          {commentSectionLen > 5 && (
+            <Button
+              variant="contained"
+              size="sm"
+              onClick={() => setCommentSectionLen((prevLen) => prevLen - 5)}
+            >
+              Fewer comments ↑
+            </Button>
+          )}
+        </div>
       </Modal.Body>
       <Modal.Footer>
         {user.email && (


### PR DESCRIPTION
For posts with more than 5 comments, it will by default show the most recent 5. The user can toggle between showing more comments and fewer comments by clicking on a button.

Click "more comments" to show the next 5 most recent comments:
<img width="666" alt="Screenshot 2023-03-14 at 9 44 28 AM" src="https://user-images.githubusercontent.com/48173359/224870902-6909bd8e-e122-4203-ae9c-360b9512b24b.png">

If more than 5 comments are shown, the "fewer comments" becomes visible:
<img width="574" alt="Screenshot 2023-03-14 at 9 44 35 AM" src="https://user-images.githubusercontent.com/48173359/224870670-5056dbbe-3efe-4cb9-9782-26195a110665.png">
