### PR TITLE
Phase 2 of friends-related features: view and accept friend requests

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,11 +8,6 @@
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
 .App-header {
   background-color: #282c34;
   height: 100vh;
@@ -58,12 +53,24 @@
   padding: 0;
 }
 
-#num-of-pending-requests {
-  background-color: rgb(255, 130, 130);
-  width: 20px;
-  margin-left: 2vmin;
-  padding: 0.3vmin 1vmin 0 1vmin;
-  border-radius: 3vmin;
+.dropdown-item {
+  display: flex;
+  justify-content: space-between;
+}
+
+.num-of-requests {
+  padding: 0.2vmin 1.2vmin;
+  border-radius: 2vmin;
+  font-size: calc(10px + 0.8vmin);
+}
+
+#pending-requests {
+  background-color: #ff5d6c;
+  color: #ffffff;
+}
+
+#no-pending-requests {
+  background-color: rgb(210, 210, 210);
 }
 
 /* Post Form */
@@ -109,7 +116,6 @@
 }
 
 /* Posts */
-
 .modal-content-happy {
   border-right: 6px #d1f7b1 solid;
   border-bottom: 6px #d1f7b1 solid;
@@ -243,4 +249,19 @@
 .search-result .friend-btn {
   width: 32%;
   font-size: calc(8px + 0.7vmin);
+}
+
+/* Friend manager */
+.friends-container {
+  margin: 1vmin 0;
+}
+
+.friends-container .header {
+  font-weight: 600;
+}
+
+.friend-request {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -23,12 +23,6 @@
   justify-content: center;
 }
 
-.navbar {
-  width: 100vw;
-  color: #1f2022;
-  padding: 0;
-}
-
 #logo {
   max-width: 100%;
   max-height: 6vh;
@@ -55,6 +49,21 @@
   display: flex;
   justify-content: space-evenly;
   margin-top: 2vmin;
+}
+
+/* Nav Bar */
+.navbar {
+  width: 100vw;
+  color: #1f2022;
+  padding: 0;
+}
+
+#num-of-pending-requests {
+  background-color: rgb(255, 130, 130);
+  width: 20px;
+  margin-left: 2vmin;
+  padding: 0.3vmin 1vmin 0 1vmin;
+  border-radius: 3vmin;
 }
 
 /* Post Form */

--- a/src/App.css
+++ b/src/App.css
@@ -235,10 +235,9 @@
   margin-right: calc(4px + 0.5vmin);
 }
 
-#results-found {
+.grey-italics {
   font-style: italic;
   color: rgb(145, 145, 145);
-  margin-top: 2vmin;
 }
 
 .search-results {

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import LoginForm from "./Components/LoginForm.js";
 import NavBar from "./Components/NavBar.js";
 import PostForm from "./Components/PostForm.jsx";
 import FriendFinder from "./Components/FriendFinder.js";
+import FriendManager from "./Components/FriendManager.js";
 import "./App.css";
 
 export const UserContext = React.createContext({ email: null });
@@ -124,6 +125,7 @@ function App() {
               <Route path="post-form" element={<PostForm />} />
               <Route path="posts/:postId" element={<Post />} />
               <Route path="friend-finder" element={<FriendFinder />} />
+              <Route path="friend-manager" element={<FriendManager />} />
             </Route>
           </Routes>
         </UserContext.Provider>

--- a/src/App.js
+++ b/src/App.js
@@ -126,7 +126,7 @@ function App() {
     <div className="App">
       <header className="App-header">
         <UserContext.Provider value={user}>
-          <NavBar signOutUser={signOutUser} />
+          <NavBar signOutUser={signOutUser} userDatabaseKey={userDatabaseKey} />
           <Routes>
             <Route
               path="/"

--- a/src/App.js
+++ b/src/App.js
@@ -94,6 +94,7 @@ function App() {
       uid: user.uid,
       email: user.email,
       requestsReceived: { userKey: { email: "", status: null } },
+      requestsSent: { userKey: { email: "", status: null } },
       friends: { userKey: { email: "", status: null } },
     });
   };

--- a/src/Components/FriendFinder.js
+++ b/src/Components/FriendFinder.js
@@ -100,7 +100,7 @@ export default function FriendFinder(props) {
       return (
         <Button
           className="friend-btn"
-          variant="secondary"
+          variant="success"
           size="sm"
           disabled={true}
         >
@@ -111,7 +111,7 @@ export default function FriendFinder(props) {
       return (
         <Button
           className="friend-btn"
-          variant="secondary"
+          variant="success"
           size="sm"
           disabled={true}
         >
@@ -122,7 +122,7 @@ export default function FriendFinder(props) {
       return (
         <Button
           className="friend-btn"
-          variant="secondary"
+          variant="success"
           size="sm"
           id={searchResult.userDatabaseKey}
           onClick={sendFriendRequest}
@@ -151,12 +151,12 @@ export default function FriendFinder(props) {
                 onChange={handleChange}
                 autoFocus
               />
-              <Button variant="primary" type="submit" onClick={null}>
+              <Button variant="secondary" type="submit" onClick={null}>
                 Search
               </Button>
             </Form.Group>
           </Form>
-          <div id="results-found">
+          <div className="grey-italics">
             {searchResults.length}{" "}
             {searchResults.length > 1 ? "users found" : "user found"}
           </div>

--- a/src/Components/FriendFinder.js
+++ b/src/Components/FriendFinder.js
@@ -16,11 +16,11 @@ export default function FriendFinder() {
   useEffect(() => {
     const usersRef = ref(database, USERS_DATABASE_KEY);
     onChildAdded(usersRef, (data) => {
-      if (!users.map((user) => user.id).includes(data.key)) {
+      if (!users.map((user) => user.userDatabaseKey).includes(data.key)) {
         setUsers((users) => [
           ...users,
           {
-            id: data.key,
+            userDatabaseKey: data.key,
             email: data.val().email,
             friended: data
               .val()
@@ -60,6 +60,9 @@ export default function FriendFinder() {
           requestsReceived: [
             ...existingRequests,
             {
+              userDatabaseKey: users.filter(
+                (eachUser) => eachUser.email === user.email
+              )[0].userDatabaseKey,
               email: user.email,
               status: false,
             },
@@ -74,7 +77,7 @@ export default function FriendFinder() {
   const updateSearchResults = (e) => {
     const searchResultsToUpdate = [...searchResults];
     for (const result of searchResultsToUpdate) {
-      if (result.id === e.target.id) {
+      if (result.userDatabaseKey === e.target.id) {
         result.requested = true;
         break;
       }
@@ -84,7 +87,7 @@ export default function FriendFinder() {
 
   const renderSearchResults = () => {
     return searchResults.map((result) => (
-      <div key={result.id} className="search-result">
+      <div key={result.userDatabaseKey} className="search-result">
         <div className="search-result-email">{result.email}</div>
         {renderFriendRequestBtn(result)}
       </div>
@@ -120,7 +123,7 @@ export default function FriendFinder() {
           className="friend-btn"
           variant="secondary"
           size="sm"
-          id={searchResult.id}
+          id={searchResult.userDatabaseKey}
           onClick={sendFriendRequest}
         >
           Add friend

--- a/src/Components/FriendFinder.js
+++ b/src/Components/FriendFinder.js
@@ -25,9 +25,13 @@ export default function FriendFinder(props) {
             friended: Object.values(data.val().friends)
               .map((friend) => friend.email)
               .includes(user.email),
-            requested: Object.values(data.val().requestsReceived)
-              .map((req) => req.email)
-              .includes(user.email),
+            requested:
+              Object.values(data.val().requestsReceived)
+                .map((req) => req.email)
+                .includes(user.email) ||
+              Object.values(data.val().requestsSent)
+                .map((req) => req.email)
+                .includes(user.email),
           },
         ]);
       }
@@ -49,12 +53,23 @@ export default function FriendFinder(props) {
   };
 
   const sendFriendRequest = (e) => {
-    const requestRef = ref(
+    const requestsReceivedRef = ref(
       database,
       `${USERS_DATABASE_KEY}/${e.target.id}/requestsReceived/${props.userDatabaseKey}`
     );
-    set(requestRef, {
+    set(requestsReceivedRef, {
       email: user.email,
+      status: false,
+    });
+
+    const requestsSentRef = ref(
+      database,
+      `${USERS_DATABASE_KEY}/${props.userDatabaseKey}/requestsSent/${e.target.id}`
+    );
+    set(requestsSentRef, {
+      email: searchResults.filter(
+        (result) => result.userDatabaseKey === e.target.id
+      )[0].email,
       status: false,
     });
     updateSearchResults(e);

--- a/src/Components/FriendManager.js
+++ b/src/Components/FriendManager.js
@@ -27,11 +27,6 @@ export default function FriendManager(props) {
   };
 
   const updateRequestReceived = (e) => {
-    // const updatedRequest = {};
-    // update[
-    //   `${USERS_DATABASE_KEY}/${props.userDatabaseKey}/requestsReceived/${e.target.id}`
-    // ] = { email: requests[e.target.id].email, status: true };
-    // update(ref(database), updatedRequest);
     const requestRef = ref(
       database,
       `${USERS_DATABASE_KEY}/${props.userDatabaseKey}/requestsReceived/${e.target.id}`
@@ -63,7 +58,9 @@ export default function FriendManager(props) {
             <Button id={key} onClick={handleAccept}>
               Accept
             </Button>
-            <Button id={key}>Reject</Button>
+            <Button id={key} disabled={true}>
+              Reject
+            </Button>
           </div>
         );
       }
@@ -89,7 +86,9 @@ export default function FriendManager(props) {
         <CloseButton onClick={() => navigate("/")} />
       </Modal.Header>
       <Modal.Body>
-        <div id="friend-requests-container">{renderPendingRequests()}</div>
+        <div id="friend-requests-container">
+          Pending requests: {renderPendingRequests()}
+        </div>
         <div id="friends-container">My friends: {renderMyFriends()}</div>
       </Modal.Body>
     </Modal>

--- a/src/Components/FriendManager.js
+++ b/src/Components/FriendManager.js
@@ -1,0 +1,42 @@
+import { useState, useEffect, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { database } from "../Firebase.js";
+import { USERS_DATABASE_KEY } from "../App.js";
+import { onChildAdded, ref, onValue, update } from "firebase/database";
+import { UserContext } from "../App.js";
+import { Modal, CloseButton, Button } from "react-bootstrap";
+
+export default function FriendManager() {
+  const user = useContext(UserContext);
+  const [userDatabaseKey, setUserDatabaseKey] = useState();
+  const [requests, setRequests] = useState();
+
+  useEffect(() => {}, [user.email]);
+
+  useEffect(() => {
+    const requestsRef = ref(
+      database,
+      `${USERS_DATABASE_KEY}/${userDatabaseKey}`
+    );
+    onValue(requestsRef, (snapshot) => {
+      // setRequests...
+    });
+  }, []);
+
+  const navigate = useNavigate();
+  return (
+    <Modal show={true}>
+      <Modal.Header>
+        <Modal.Title>FRIEND REQUESTS</Modal.Title>
+        <CloseButton onClick={() => navigate("/")} />
+      </Modal.Header>
+      <Modal.Body>
+        <div id="friend-requests-container">
+          {/* <div className="friend-request">placeholder: lala@abc.com</div>
+          <Button>Accept</Button>
+          <Button>Decline</Button> */}
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/src/Components/FriendManager.js
+++ b/src/Components/FriendManager.js
@@ -8,20 +8,31 @@ import { Modal, CloseButton, Button } from "react-bootstrap";
 
 export default function FriendManager() {
   const user = useContext(UserContext);
-  const [userDatabaseKey, setUserDatabaseKey] = useState();
-  const [requests, setRequests] = useState();
-
-  useEffect(() => {}, [user.email]);
+  const [userDatabaseKey, setUserDatabaseKey] = useState("");
+  const [requests, setRequests] = useState([]);
+  const [friends, setFriends] = useState([]);
 
   useEffect(() => {
-    const requestsRef = ref(
-      database,
-      `${USERS_DATABASE_KEY}/${userDatabaseKey}`
-    );
-    onValue(requestsRef, (snapshot) => {
-      // setRequests...
+    const usersRef = ref(database, USERS_DATABASE_KEY);
+    onChildAdded(usersRef, (userData) => {
+      if (userData.val().email === user.email) {
+        setUserDatabaseKey(userData.key);
+        setRequests(userData.val().requestsReceived.slice(1));
+        setFriends(userData.val().friends.slice(1));
+      }
     });
-  }, []);
+  }, [user.email]);
+
+  const renderPendingRequests = () => {
+    const pendingRequests = requests.filter(
+      (request) => request.status === false
+    );
+    return pendingRequests.map((request) => (
+      <div>
+        {request.email} <Button>Accept</Button>
+      </div>
+    ));
+  };
 
   const navigate = useNavigate();
   return (
@@ -31,11 +42,7 @@ export default function FriendManager() {
         <CloseButton onClick={() => navigate("/")} />
       </Modal.Header>
       <Modal.Body>
-        <div id="friend-requests-container">
-          {/* <div className="friend-request">placeholder: lala@abc.com</div>
-          <Button>Accept</Button>
-          <Button>Decline</Button> */}
-        </div>
+        <div id="friend-requests-container">{renderPendingRequests()}</div>
       </Modal.Body>
     </Modal>
   );

--- a/src/Components/FriendManager.js
+++ b/src/Components/FriendManager.js
@@ -120,12 +120,20 @@ export default function FriendManager(props) {
         <CloseButton onClick={() => navigate("/")} />
       </Modal.Header>
       <Modal.Body>
-        {renderPendingRequests().length > 0 && (
-          <div className="friends-container" id="friend-requests">
-            <div className="header">Pending requests:</div>
-            {renderPendingRequests()}
-          </div>
-        )}
+        <div className="friends-container" id="friend-requests">
+          {renderPendingRequests().length > 0 ? (
+            <>
+              <div className="header">Pending requests:</div>
+              {renderPendingRequests()}
+            </>
+          ) : (
+            <div className="grey-italics">
+              No pending friend requests at the moment
+            </div>
+          )}
+        </div>
+      </Modal.Body>
+      <Modal.Body>
         <div className="friends-container" id="my-friends">
           <div className="header">My friends:</div>
           {renderMyFriends()}

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -1,16 +1,41 @@
-import { useContext } from "react";
+import { useState, useContext, useEffect } from "react";
 import { UserContext } from "../App";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 import NavDropdown from "react-bootstrap/NavDropdown";
 import { useLocation, useNavigate } from "react-router-dom";
 import logo from "../Icons/AniMap-2.png";
-import { Button } from "react-bootstrap";
+import { database } from "../Firebase.js";
+import { ref, onValue } from "firebase/database";
+import { USERS_DATABASE_KEY } from "../App.js";
 
 export default function NavBar(props) {
   const user = useContext(UserContext);
   const navigate = useNavigate();
   let location = useLocation();
+
+  const [pendingRequests, setPendingRequests] = useState([]);
+
+  useEffect(() => {
+    const userRef = ref(
+      database,
+      `${USERS_DATABASE_KEY}/${props.userDatabaseKey}`
+    );
+    onValue(userRef, (snapshot) => {
+      // console.log(
+      //   Object.values(snapshot.val().requestsReceived).filter(
+      //     (req) => req.status === false
+      //   )
+      // );
+      if (snapshot.val().requestsReceived) {
+        setPendingRequests(
+          Object.values(snapshot.val().requestsReceived).filter(
+            (req) => req.status === false
+          )
+        );
+      }
+    });
+  }, [props]);
 
   return (
     <Navbar bg="light" variant="light" sticky="top">
@@ -29,6 +54,7 @@ export default function NavBar(props) {
               }}
             >
               Friend requests
+              <span id="num-of-pending-requests">{pendingRequests.length}</span>
             </NavDropdown.Item>
             <NavDropdown.Item
               onClick={() => {

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -68,13 +68,13 @@ export default function NavBar(props) {
               Sign out
             </NavDropdown.Item>
           </NavDropdown>
-          <Nav.Link onClick={() => navigate("post-form")}>Posts</Nav.Link>
+          <Nav.Link onClick={() => navigate("post-form")}>Post</Nav.Link>
           <Nav.Link
             onClick={() => {
               navigate("q");
             }}
           >
-            Posts Filter
+            Filter
           </Nav.Link>
         </Nav>
       )}

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -44,17 +44,26 @@ export default function NavBar(props) {
       </Navbar.Brand>
       {user.email && location !== "/login-signup" && (
         <Nav id="logged-in-nav">
-          <NavDropdown
-            title={`Welcome, ${user.email.split("@")[0]}!`}
-            id="collasible-nav-dropdown"
-          >
+          <NavDropdown title="Account" id="collasible-nav-dropdown">
+            <NavDropdown.Header>{`Welcome, ${
+              user.email.split("@")[0]
+            }!`}</NavDropdown.Header>
+            <NavDropdown.Divider />
             <NavDropdown.Item
               onClick={() => {
                 navigate("friend-manager");
               }}
             >
-              Friend requests
-              <span id="num-of-pending-requests">{pendingRequests.length}</span>
+              My friends
+              {pendingRequests.length > 0 ? (
+                <span className="num-of-requests" id="pending-requests">
+                  {pendingRequests.length}
+                </span>
+              ) : (
+                <span className="num-of-requests" id="no-pending-requests">
+                  0
+                </span>
+              )}
             </NavDropdown.Item>
             <NavDropdown.Item
               onClick={() => {

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -22,7 +22,13 @@ export default function NavBar(props) {
             title={`Welcome, ${user.email.split("@")[0]}!`}
             id="collasible-nav-dropdown"
           >
-            <NavDropdown.Item>Friend requests</NavDropdown.Item>
+            <NavDropdown.Item
+              onClick={() => {
+                navigate("friend-manager");
+              }}
+            >
+              Friend requests
+            </NavDropdown.Item>
             <NavDropdown.Item
               onClick={() => {
                 navigate("friend-finder");


### PR DESCRIPTION
I have added a FriendManager component which displays pending friend requests and allows users to accept them (rejection will be in Phase 3).

So after user clicks "add friend" in FriendFinder, the friend request will be created in the realtime database and saved in both the requestor and the receiver's user data. The receiver will see that they have a pending request from the NavBar:
<img width="254" alt="Screenshot 2023-03-16 at 12 53 30 PM" src="https://user-images.githubusercontent.com/48173359/225518411-479e5a6f-73a8-418d-ad54-d7d363f1fe4b.png">

The receiver can click on "My friends" from the NavBar dropdown and view the pending requests:
<img width="523" alt="Screenshot 2023-03-16 at 12 53 44 PM" src="https://user-images.githubusercontent.com/48173359/225518554-695141bf-c14f-4932-9141-40dd4d43a915.png">

After clicking "accept", the new friend will be added to the list of friends in the same view:
<img width="524" alt="Screenshot 2023-03-16 at 12 53 54 PM" src="https://user-images.githubusercontent.com/48173359/225518615-88e50fbe-ba60-466a-a6a4-c46f2237f309.png">

If the user does a fresh search for friends, they will see the friend status reflected in the search.
<img width="525" alt="Screenshot 2023-03-16 at 12 54 12 PM" src="https://user-images.githubusercontent.com/48173359/225518651-673ffd81-bb6f-4293-8c76-425d024f16c0.png">

