### PR TITLE
Dynamic marker sizing: the more zoomed in, the larger the markers

### DIFF
--- a/src/Components/MapFeed.js
+++ b/src/Components/MapFeed.js
@@ -25,6 +25,8 @@ const POSTS_DATABASE_KEY = "posts";
 export default function MapFeed(props) {
   const navigate = useNavigate();
   const [posts, setPosts] = useState([]);
+  const [map, setMap] = useState(null);
+  const [zoom, setZoom] = useState(12);
 
   useEffect(() => {
     const postsRef = ref(database, POSTS_DATABASE_KEY);
@@ -45,6 +47,17 @@ export default function MapFeed(props) {
     });
   }, []);
 
+  const handleLoad = (mapInstance) => {
+    setMap(mapInstance);
+  };
+
+  const handleZoomChanged = () => {
+    if (map) {
+      console.log(map.getZoom());
+      setZoom(map.getZoom());
+    }
+  };
+
   const setMarkerParams = (animal, encounter) => {
     const icons = {
       happycat: { url: catIconG },
@@ -53,7 +66,11 @@ export default function MapFeed(props) {
       unhappyotter: { url: otterIconR },
     };
     Object.keys(icons).forEach(
-      (key) => (icons[key].scaledSize = new window.google.maps.Size(40, 55))
+      (key) =>
+        (icons[key].scaledSize = new window.google.maps.Size(
+          Math.pow(zoom / 15, 2) * 40,
+          Math.pow(zoom / 15, 2) * 55
+        ))
     );
     return icons[`${encounter}${animal}`];
   };
@@ -79,7 +96,13 @@ export default function MapFeed(props) {
 
   return (
     <LoadScript googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}>
-      <GoogleMap mapContainerStyle={containerStyle} center={center} zoom={12}>
+      <GoogleMap
+        mapContainerStyle={containerStyle}
+        center={center}
+        zoom={12}
+        onLoad={handleLoad}
+        onZoomChanged={handleZoomChanged}
+      >
         {renderMarkers(posts)}
         <Outlet />
       </GoogleMap>


### PR DESCRIPTION
The markers used to be the same size, regardless of how zoomed in. The problem is that if there are a few markers in the same area, they start to look like one marker when zoomed out.

Lower zoom-level, smaller markers:
<img width="205" alt="Screenshot 2023-03-16 at 3 07 21 PM" src="https://user-images.githubusercontent.com/48173359/225541375-687b7659-beb5-4d28-85e2-3bab43200da1.png">

Higher zoom-level, larger markers:
<img width="205" alt="Screenshot 2023-03-16 at 3 08 41 PM" src="https://user-images.githubusercontent.com/48173359/225541486-a670953f-6588-404d-93cb-f754d26dfe6a.png">
