### PR TITLE
Fixed bug with friend requests

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -138,10 +138,6 @@
   color: #ffffff;
 }
 
-#no-pending-requests {
-  background-color: rgb(210, 210, 210);
-}
-
 .circle {
   background-color: rgba(0, 0, 0, 0.1);
   border-radius: 50%;

--- a/src/Components/FriendFinder.js
+++ b/src/Components/FriendFinder.js
@@ -60,7 +60,7 @@ export default function FriendFinder() {
     );
     set(requestsReceivedRef, {
       email: user.email,
-      status: false,
+      // status: false,
     });
 
     const requestsSentRef = ref(
@@ -71,7 +71,7 @@ export default function FriendFinder() {
       email: searchResults.filter(
         (result) => result.userDatabaseKey === e.target.id
       )[0].email,
-      status: false,
+      // status: false,
     });
     updateSearchResults(e);
   };

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -24,7 +24,7 @@ export default function NavBar(props) {
         if (snapshot.val().requestsReceived) {
           setPendingRequests(
             Object.values(snapshot.val().requestsReceived).filter(
-              (req) => req.status === false
+              (req) => req.email !== ""
             )
           );
         }
@@ -63,15 +63,11 @@ export default function NavBar(props) {
                 navigate("friend-manager");
               }}
             >
-              <div>My friends</div>
-              {pendingRequests.length > 0 ? (
+              <div>View friends</div>
+              {pendingRequests.length > 0 && (
                 <div className="num-of-requests" id="pending-requests">
                   {pendingRequests.length}
                 </div>
-              ) : (
-                <span className="num-of-requests" id="no-pending-requests">
-                  0
-                </span>
               )}
             </NavDropdown.Item>
             <NavDropdown.Item


### PR DESCRIPTION
Requests used to be stored as an object with an attribute "status" (false if outstanding, true if accepted). This makes unfriending more complicated, by requiring finding the accepted request from both the sender and the receiver and removing it.

I removed the "status" attribute, so that each requestsReceived in the database is an outstanding request. Upon acceptance or rejection, the requestsReceived and requestsSent are removed from the database. 

As suggested by Ivan, the "View friends" tab in the nav dropdown no longer displays zero outstanding friend requests.  