### PR TITLE
Minor fix: public/friends-only posts, button styling, Readme

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "animap-2deae"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,30 +1,17 @@
-# Project2_AniMap
-The Ultimate Map For Animal Lovers
+# Rocket Academy Coding Bootcamp: Project 2 - AniMap
 
-Try out the app: https://animap-2deae.web.app/
+## About the App
 
-Our aims are to provide latest updates on animal sightings in Singapore.
+Welcome to AniMap, the Ultimate Map For Animal Lovers. This is a Rocket Bootcamp full-stack project.
 
-As the users sign in, a map will be rendered with pins on it.
+Give it a try [here](https://animap-2deae.web.app/)! Please sign up and follow the on-screen instructions.
 
-The pin represent a post by the community.
+Our aim is to provide a fun and safe environment for animal lovers to get the latest updates on animal sightings and share knowledge. As a start, we have launched AniMap in Singapore.
 
-Users can click the pin to view details of the sightings.
+## Available Scripts
 
-If the post is restricted, user can view only after added as friend. This is to provide privacy on certain sightings.
+This project was bootstrapped with Create React App. In the project directory, you can run _npm start_, to run the app in the development mode. Open http://localhost:3000 to view it in your browser. The page will reload when you make changes.
 
-Users can interact with each other via comments.
+The data are stored in [Firebase](https://firebase.google.com/). To work with dummy data, start a new Firebase project and follow instructions to initialize the App. Add Realtime Database, Storage, and Authentication to fully explore the App features.
 
-Available Scripts
-
-This project was bootstrapped with Create React App. In the project directory, you can run:
-
-npm start
-
-Runs the app in the development mode.
-
-Open http://localhost:3000 to view it in your browser.
-
-The page will reload when you make changes.
-
-You may also see any lint errors in the console.
+Our app uses API from [Google Maps Platform] (https://developers.google.com/maps/documentation/javascript) with a private API key.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "build",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/src/Components/MapFeed.js
+++ b/src/Components/MapFeed.js
@@ -47,7 +47,8 @@ export default function MapFeed(props) {
             authorEmail: data.val().authorEmail,
             animal: data.val().animal,
             encounter: data.val().encounter,
-            publicPost: data.val().public === "true",
+            publicPost:
+              data.val().public === "true" || data.val().public === true,
             maskedLocation: maskLocation(data.val().location),
           },
         ]);

--- a/src/Components/Post.js
+++ b/src/Components/Post.js
@@ -53,7 +53,9 @@ export default function Post(props) {
   useEffect(() => {
     const postRef = ref(database, `${POSTS_DATABASE_KEY}/${postId}`);
     onValue(postRef, (snapshot) => {
-      setPublicPost(snapshot.val().public === "true");
+      setPublicPost(
+        snapshot.val().public === "true" || snapshot.val().public === true
+      );
       setLng(snapshot.val().location.lng);
       setLat(snapshot.val().location.lat);
       setContent(snapshot.val().content);
@@ -346,12 +348,12 @@ export default function Post(props) {
               onChange={(e) => setComment(e.target.value)}
             />
             <div className="side-by-side-btns">
-              <Button type="submit" variant="primary">
+              <Button type="submit" variant="dark">
                 {editComment ? `Edit comment` : `Send comment`}
               </Button>
               <Button
                 type={null}
-                variant="primary"
+                variant="dark"
                 onClick={() => {
                   navigate("/");
                 }}


### PR DESCRIPTION
The privacy setting for earlier posts were stored as a string in the realtime database, but a boolean for the later posts. I have updated the state logic To ensure both data types are evaluated properly.

Styling changes: primary buttons are set to "dark theme".

Readme: updated available scripts portion to include instructions on Firebase and Google Maps.