### PR TITLE
Bug fix: direct users who have not signed in to sign in/sign up

### DIFF
--- a/src/Components/Help.js
+++ b/src/Components/Help.js
@@ -22,7 +22,7 @@ export default function Help() {
       </Modal.Body>
       <Modal.Body>
         Each pin on the map represents a post by the community. Click on the
-        pins to see more details.
+        pins to see more details. Some examples of pins:
         <div className="example smaller">
           <img className="icon-example" src={catIconG} alt="cat-icon" />
           This is a cat sighting
@@ -40,7 +40,7 @@ export default function Help() {
       <Modal.Body>
         Worried about safety and privacy? When drafting your post, place the pin
         on an approximate location, or select "only my friends" to restrict who
-        can see your post's location.
+        can see your post's exact location.
       </Modal.Body>
       <Modal.Footer className="grey-smaller">
         Designed and developed by

--- a/src/Components/Post.js
+++ b/src/Components/Post.js
@@ -222,7 +222,11 @@ export default function Post(props) {
           <div
             className="grey-smaller prevent-select text-overlay cursor-pointer"
             onClick={() => {
-              navigate("../friend-finder");
+              if (user.email) {
+                navigate("../friend-finder");
+              } else {
+                navigate("../login-signup");
+              }
             }}
           >
             Become {authorEmail}'s friend to view this post!


### PR DESCRIPTION
I realised that users who have not signed in might accidentally access the friend finder by clicking on the grey text at the bottom of the private post. I have thus amended the routing to direct them to the log in/sign up form instead.
<img width="508" alt="Screenshot 2023-03-22 at 3 43 09 PM" src="https://user-images.githubusercontent.com/48173359/226833717-1f96d484-9dd2-4ebc-a2dd-cd8a6289496b.png">
